### PR TITLE
Add accessibility-related attributes to <nolink>, for keyboard access

### DIFF
--- a/special_menu_items.module
+++ b/special_menu_items.module
@@ -77,7 +77,11 @@ function special_menu_items_menu_link(array $variables) {
         if (!empty($element['#original_link']['in_active_trail'])) {
           $css = 'active-trail';
         }
-        $output = special_menu_items_render_menu_item($tag, $title, $css);
+        // add attributes for keyboard and screenreader accessibility
+        // this adds to the tag, NOT the parent <li>
+        $tagattr['tabindex'][] = '0';
+        $tagattr['role'][] = 'link';
+        $output = special_menu_items_render_menu_item($tag, $title, $css, $tagattr);
         $element['#attributes']['class'][] = 'nolink';
         break;
         
@@ -114,24 +118,30 @@ function special_menu_items_menu_link(array $variables) {
 /**
  * Returns menu item rendered.
  */
-function special_menu_items_render_menu_item($tag, $value, $css = NULL) {
+function special_menu_items_render_menu_item($tag, $value, $css = NULL, $tagattr = NULL) {
   $length = strlen($tag);
+
+  if ($tagattr != NULL) { // ready attributes if they exist
+      $tagattr = drupal_attributes($tagattr);
+  }
    
   //Validate the tags
   if ($tag[0] == '<' && $tag[$length - 1] == '>') {
     $closingtag = str_replace('<', '</', $tag);
     if ($css) {
-      $tag = str_replace('>', ' class="' . $css . '">', $tag);        
+      $tag = str_replace('>', ' class="' . $css . '"' . $tagattr . '>', $tag);
     } 
+    $tag = str_replace('>', $tagattr . '>', $tag);
   } else {
     if ($css) {       
-      $classtag = '<' . $tag . ' class="' . $css . '">';
+      $classtag = '<' . $tag . ' class="' . $css . '"' . $tagattr . '>';
       $tag = '<' . $tag . '>';
       $closingtag = str_replace('<', '</', $tag);
       $tag = $classtag;
     } else {
       $tag = '<' . $tag . '>';
       $closingtag = str_replace('<', '</', $tag);
+      $tag = '<' . $tag . $tagattr . '>';
     }
   }  
 


### PR DESCRIPTION
We're working on improving the accessibility of all georgia.gov sites. Our make file points to P2's fork of special_menu_items. We have a requirement for being able to keyboard tab to and focus on a nolink `<span>`, without turning it into a `<a href="#">`, so that the child drop-down menu can be seen and its items tabbed to and selected. [For example, see the "Reports" menu item on DSO.](http://dso.georgia.gov/)

If you hover over it with a mouse, you get the drop down fine. However, if you try to tab to it, it is skipped. This can be resolved by adding `role="link"` and `tabindex="0"` attributes to the `<span>` and making it part of the regular tab flow.

(Note that getting the drop down to appear on a `<span>` focus will also require a small superfish patch, but that is outside the scope of this project.)

This code is a bit of a shoehorned approach, but it is important to add the attributes to the `<span>` and not the parent `<li>`.
